### PR TITLE
Fix for Cast groups and dash in UUID

### DIFF
--- a/sponsorblockcast.sh
+++ b/sponsorblockcast.sh
@@ -42,7 +42,7 @@ watch () {
 }
 
 scan_chromecasts() {
-  go-chromecast ls | grep -oP 'uuid="\K[^"]+' > devices
+  go-chromecast ls | grep -v 'device="Google Cast Group"' | grep -oP 'uuid="\K[^"]+' | sed 's/-//g;' > devices
 }
 
 pid_exists () {


### PR DESCRIPTION
Cast groups aren't supported for running YouTube. Additionally, dashes in the UUID caused the script to create an invalid var name, and was spawning endless copies of the script. My little server was whirring away with 238 threads of sponsorblockcast.

This change excludes Cast groups from the UUIDs filtered, and also removes dashes from UUIDs as a forward-compatibility measure in case go-chromecast behavior changes in the future.