### PR TITLE
Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM alpine:latest
+ARG SPONSORBLOCKCAST_REPO=nichobi/sponsorblockcast
+RUN apk -U add jq bc grep git go curl \
+  && git clone https://github.com/vishen/go-chromecast \
+  && cd go-chromecast \
+  && latest_release=`curl https://api.github.com/repos/vishen/go-chromecast/tags | jq -r '.[0].name'` \
+  && git pull origin $latest_release \
+  && git checkout $latest_release \
+  && go install \
+  && cp ~/go/bin/go-chromecast /usr/bin/go-chromecast \
+  && cd .. \
+  && rm -rf go-chromecast \
+  && git clone https://github.com/$SPONSORBLOCKCAST_REPO \
+  && cp  sponsorblockcast/sponsorblockcast.sh /usr/bin/sponsorblockcast \
+  && rm -rf sponsorblockcast \
+  && chmod +x /usr/bin/sponsorblockcast \
+  && chmod +x /usr/bin/go-chromecast \
+  && apk del git go curl
+ENV SBCPOLLINTERVAL 1
+ENV SBCSCANINTERVAL 300
+ENV SBCCATEGORIES sponsor
+ENV SBCDIR /tmp/sponsorblockcast
+LABEL Description="Container to run go-chromecast with some preset ENVs, run as net-mode host"
+CMD /usr/bin/sponsorblockcast

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,11 @@
 FROM alpine:latest
-ARG SPONSORBLOCKCAST_REPO=nichobi/sponsorblockcast
-RUN apk -U add jq bc grep git go curl \
-  && git clone https://github.com/vishen/go-chromecast \
-  && cd go-chromecast \
-  && latest_release=`curl https://api.github.com/repos/vishen/go-chromecast/tags | jq -r '.[0].name'` \
-  && git pull origin $latest_release \
-  && git checkout $latest_release \
-  && go install \
-  && cp ~/go/bin/go-chromecast /usr/bin/go-chromecast \
-  && cd .. \
-  && rm -rf go-chromecast \
-  && git clone https://github.com/$SPONSORBLOCKCAST_REPO \
-  && cp  sponsorblockcast/sponsorblockcast.sh /usr/bin/sponsorblockcast \
-  && rm -rf sponsorblockcast \
+ARG GC_BUILD=linux_amd64
+ADD sponsorblockcast.sh /usr/bin/sponsorblockcast
+RUN apk -U add jq bc grep \
+  && GC_URL=`wget https://api.github.com/repos/vishen/go-chromecast/releases/latest -O - | jq -r '.assets[].browser_download_url' | grep $GC_BUILD` \
+  && wget $GC_URL -O - | tar xzf - > /usr/bin/go-chromecast \
   && chmod +x /usr/bin/sponsorblockcast \
-  && chmod +x /usr/bin/go-chromecast \
-  && apk del git go curl
+  && chmod +x /usr/bin/go-chromecast
 ENV SBCPOLLINTERVAL 1
 ENV SBCSCANINTERVAL 300
 ENV SBCCATEGORIES sponsor

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN apk -U add jq bc grep \
   && GC_URL=`wget https://api.github.com/repos/vishen/go-chromecast/releases/latest -O - | jq -r '.assets[].browser_download_url' | grep $GC_BUILD` \
   && wget $GC_URL -O - | tar xzf - > /usr/bin/go-chromecast \
   && chmod +x /usr/bin/sponsorblockcast \
-  && chmod +x /usr/bin/go-chromecast
+  && chmod +x /usr/bin/go-chromecast \
+  && rm -rf /var/cache/apk/* /lib/apk/db/* /root/*
 ENV SBCPOLLINTERVAL 1
 ENV SBCSCANINTERVAL 300
 ENV SBCCATEGORIES sponsor

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The script will scan for all Chromecasts on the LAN, and launches a process for 
 ### Arch Linux
 Install [sponsorblockcast-git](https://aur.archlinux.org/packages/sponsorblockcast-git) with your [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers) of choice or with [makepkg](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_and_upgrading_packages).
 ### Docker image
-You can [install Docker](https://docs.docker.com/engine/install/) directly or use [Docker Compose](https://docs.docker.com/compose/install/) (Or use Podman, Portainer, etc).
+You can [install Docker](https://docs.docker.com/engine/install/) directly or use [Docker Compose](https://docs.docker.com/compose/install/) (Or use Podman, Portainer, etc). Please note you *MUST* use the 'host' network as shown below for CLI Docker or in the example for `docker-compose`.
  ### Docker
 
 Run the below commands as root or a member of the `docker` group

--- a/README.md
+++ b/README.md
@@ -8,15 +8,16 @@ The script will scan for all Chromecasts on the LAN, and launches a process for 
 ## Installation
 ### Arch Linux
 Install [sponsorblockcast-git](https://aur.archlinux.org/packages/sponsorblockcast-git) with your [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers) of choice or with [makepkg](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_and_upgrading_packages).
+
 ### Docker image
 You can [install Docker](https://docs.docker.com/engine/install/) directly or use [Docker Compose](https://docs.docker.com/compose/install/) (Or use Podman, Portainer, etc). Please note you *MUST* use the 'host' network as shown below for CLI Docker or in the example for `docker-compose`.
- ### Docker
 
+#### Docker
 Run the below commands as root or a member of the `docker` group
 * `docker build . -t sponsorblockcast:latest`
 * `docker run --network=host --name sponsorblockcast sponsorblockcast:latest`
- ### Docker Compose
 
+#### Docker Compose
 First you will need a `docker-compose.yaml` file, such as the example included. Run the below commands as root or a member of the `docker` group
 * `docker-compose build`
 * `docker-compose up -d`

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Environment="SBCSCANINTERVAL=100"
 Environment="SBCCATEGORIES=sponsor selfpromo"
 ```
 
+To modify the variables when running as a Docker container, you can add arguments to the `docker run` command like so:
+
+`docker run --network=host --env SBCPOLLINTERVAL=10 --env SBCSCANINTERVAL=100 --name sponsorblockcast sponsorblockcast:latest`
+
+When using `docker-compose.yaml` you can simply edit the `environment` directive as shown in the example file.
+
 ## Differences from CastBlock
 * Regular scans to find new Chromecasts while the script is running
 * Allows configuring parameters

--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ The script will scan for all Chromecasts on the LAN, and launches a process for 
 ## Installation
 ### Arch Linux
 Install [sponsorblockcast-git](https://aur.archlinux.org/packages/sponsorblockcast-git) with your [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers) of choice or with [makepkg](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_and_upgrading_packages).
+### Docker image
+You can [install Docker](https://docs.docker.com/engine/install/) directly or use [Docker Compose](https://docs.docker.com/compose/install/) (Or use Podman, Portainer, etc).
+ ### Docker
+
+Run the below commands as root or a member of the `docker` group
+* `docker build . -t sponsorblockcast:latest`
+* `docker run --network=host --name sponsorblockcast sponsorblockcast:latest`
+ ### Docker Compose
+
+First you will need a `docker-compose.yaml` file, such as the example included. Run the below commands as root or a member of the `docker` group
+* `docker-compose build`
+* `docker-compose up -d`
+
 ### Manual installation
 #### Dependencies
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: '3.6'
+services:
+  sponsorblockcast:
+    build: 
+      context: .
+      cache_from:
+        - alpine:latest
+    image: sponsorblockcast:latest
+    network_mode: host
+    cap_add: 
+      - NET_ADMIN
+    restart: always

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,11 @@ services:
         - alpine:latest
     image: sponsorblockcast:latest
     network_mode: host
+    environment:
+      SBCPOLLINTERVAL: 1
+      SBCSCANINTERVAL: 300
+      SBCCATEGORIES: sponsor
+      SBCDIR: /tmp/sponsorblockcast
     cap_add: 
       - NET_ADMIN
     restart: always

--- a/sponsorblockcast.sh
+++ b/sponsorblockcast.sh
@@ -42,7 +42,7 @@ watch () {
 }
 
 scan_chromecasts() {
-  go-chromecast ls | grep -oP 'uuid="\K[^"]+' > devices
+  go-chromecast ls | grep -v 'device="Google Cast Group"' | grep -oP 'uuid="\K[^"]+' | sed 's/-//g;' > devices
 }
 
 pid_exists () {


### PR DESCRIPTION
Adding a Dockerfile using the Alpine image. Currently this results in a 24.6 MB Docker image using Alpine and using native binaries when possible. Dockerfile finds latest binary build release from go-chromecast and downloads into image. Can change `GC_BUILD` build-arg at build time to build for a different platform such as a Raspberry Pi.