### PR TITLE
Fix for bug using wget in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ ARG GC_BUILD=linux_amd64
 ADD sponsorblockcast.sh /usr/bin/sponsorblockcast
 RUN apk -U add jq bc grep \
   && GC_URL=`wget https://api.github.com/repos/vishen/go-chromecast/releases/latest -O - | jq -r '.assets[].browser_download_url' | grep $GC_BUILD` \
-  && wget $GC_URL -O - | tar xzf - > /usr/bin/go-chromecast \
+  && wget $GC_URL -O /root/go-chromecast.tgz \
+  && tar xzf /root/go-chromecast.tgz -C /usr/bin \
   && chmod +x /usr/bin/sponsorblockcast \
   && chmod +x /usr/bin/go-chromecast \
   && rm -rf /var/cache/apk/* /lib/apk/db/* /root/*


### PR DESCRIPTION
I thought I caught this but I missed this somehow, I'm so sorry! This is fixing an issue where it created a zero-byte file at /usr/bin/go-chromecast inside the container. So much for shell-piping wizardry!