### PR TITLE
Build and distribute Docker image

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -1,0 +1,37 @@
+name: build-and-push-image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-multi-arch-image:
+    name: Build multi-arch Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true 
+          tags: ghcr.io/${{ github.repository }}:latest
+          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,23 @@
 FROM alpine:latest
-ARG GC_BUILD=linux_amd64
-ADD sponsorblockcast.sh /usr/bin/sponsorblockcast
-RUN apk -U add jq bc grep curl \
-  && GC_URL=`wget https://api.github.com/repos/vishen/go-chromecast/releases/latest -O - | jq -r '.assets[].browser_download_url' | grep $GC_BUILD` \
+
+# Add the BuildKit global arch args to get the correct go-chromecast release
+# go-chromecast package linux architectures: linux_386, linux_amd64, linux_arm64, linux_armv6, linux_armv7
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+RUN apk --no-cache add jq bc grep curl \
+  && GC_URL=`wget https://api.github.com/repos/vishen/go-chromecast/releases/latest -O - | jq -r '.assets[].browser_download_url' | grep ${TARGETOS}_${TARGETARCH}${TARGETVARIANT}` \
   && wget $GC_URL -O /root/go-chromecast.tgz \
   && tar xzf /root/go-chromecast.tgz -C /usr/bin \
-  && chmod +x /usr/bin/sponsorblockcast \
-  && chmod +x /usr/bin/go-chromecast \
-  && rm -rf /var/cache/apk/* /lib/apk/db/* /root/*
+  && chmod +x /usr/bin/go-chromecast
+
 ENV SBCPOLLINTERVAL 1
 ENV SBCSCANINTERVAL 300
 ENV SBCCATEGORIES sponsor
 ENV SBCDIR /tmp/sponsorblockcast
 LABEL Description="Container to run go-chromecast with some preset ENVs, run as net-mode host"
+
+ADD sponsorblockcast.sh /usr/bin/sponsorblockcast
+
 CMD /usr/bin/sponsorblockcast

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apk --no-cache add jq bc grep curl \
   && GC_URL=`wget https://api.github.com/repos/vishen/go-chromecast/releases/latest -O - | jq -r '.assets[].browser_download_url' | grep ${TARGETOS}_${TARGETARCH}${TARGETVARIANT}` \
   && wget $GC_URL -O /root/go-chromecast.tgz \
   && tar xzf /root/go-chromecast.tgz -C /usr/bin \
+  && rm -rf /root/* \
   && chmod +x /usr/bin/go-chromecast
 
 ENV SBCPOLLINTERVAL 1

--- a/README.md
+++ b/README.md
@@ -14,12 +14,10 @@ You can [install Docker](https://docs.docker.com/engine/install/) directly or us
 
 #### Docker
 Run the below commands as root or a member of the `docker` group
-* `docker build . -t sponsorblockcast:latest`
-* `docker run --network=host --name sponsorblockcast sponsorblockcast:latest`
+* `docker run --network=host --name sponsorblockcast ghcr.io/nichobi/sponsorblockcast:latest`
 
 #### Docker Compose
 First you will need a `docker-compose.yaml` file, such as the example included. Run the below commands as root or a member of the `docker` group
-* `docker-compose build`
 * `docker-compose up -d`
 
 ### Manual installation

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,11 +1,7 @@
 version: '3.6'
 services:
   sponsorblockcast:
-    build: 
-      context: .
-      cache_from:
-        - alpine:latest
-    image: sponsorblockcast:latest
+    image: ghcr.io/nichobi/sponsorblockcast:latest
     network_mode: host
     environment:
       SBCPOLLINTERVAL: 1


### PR DESCRIPTION
Adds the following:

- Dynamic multi-arch support to the Dockerfile (linux/amd64, linux/386, linux/arm64, linux/arm/v7, linux/arm/v6)
- GitHub Actions workflow that automatically builds the Docker image and publishes it to the GitHub Container Registry on this project
- Updates docs to reference prebuilt Docker image
- Minor optimizations to the Dockerfile

Before merging, I believe you'll need to enable the "Improved container support" feature in the [GitHub feature preview](https://docs.github.com/en/get-started/using-github/exploring-early-access-releases-with-feature-preview#exploring-beta-releases-with-feature-preview) window.

Once merged, you should see the images appear in the "Packages" section of your repository. You can see an example on [my fork](https://github.com/claabs/sponsorblockcast/pkgs/container/sponsorblockcast).