### PR TITLE
Fix for 4th gen Chromecast

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+disable=SC2016

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This will open a blank override file where you can specify Environment values li
 Environment="SBCPOLLINTERVAL=10"
 Environment="SBCSCANINTERVAL=100"
 Environment="SBCCATEGORIES=sponsor selfpromo"
+SBCYOUTUBEAPIKEY="your private API key"
 ```
 
 To modify the variables when running as a Docker container, you can add arguments to the `docker run` command like so:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ First you will need a `docker-compose.yaml` file, such as the example included. 
 * Copy [sponsorblockcast.service](/sponsorblockcast.service) to `/usr/lib/systemd/system/sponsorblockcast.service`.
 
 ## Usage
-Run `sponsorblockcast` from a terminal or activate the service with `systemd enable --now sponsorblockcast`
+Run `sponsorblockcast` from a terminal or activate the service with `systemd enable sponsorblockcast && systemctl start sponsorblockcast`
 
 ## Configuration
 You can configure the following parameters by setting the appropriate enviroment values:
@@ -39,6 +39,7 @@ You can configure the following parameters by setting the appropriate enviroment
 * `SBCSCANINTERVAL` - Time to wait between each scan for available Chromecast (default=`300`)
 * `SBCDIR` - Directory where temporary files are stored (default=`/tmp/sponsorblockcast`)
 * `SBCCATEGORIES` - Space-separated SponsorBlock categories to skip, see [category list](https://github.com/ajayyy/SponsorBlock/blob/master/config.json.example) (default=`sponsor`)
+* `SBCYOUTUBEAPIKEY` - [YouTube API key](https://developers.google.com/youtube/registering_an_application) for fallback video identification (required on some Chromecast devices).
 
 To run from the terminal with custom parameters you can use `env` like so:
 `env SBCSCANINTERVAL=10 SBCPOLLINTERVAL=100 SBCCATEGORIES="sponsor selfpromo" sponsorblockcast`

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ First you will need a `docker-compose.yaml` file, such as the example included. 
 * Copy [sponsorblockcast.service](/sponsorblockcast.service) to `/usr/lib/systemd/system/sponsorblockcast.service`.
 
 ## Usage
-Run `sponsorblockcast` from a terminal or activate the service with `systemd enable sponsorblockcast && systemctl start sponsorblockcast`
+Run `sponsorblockcast` from a terminal or activate the service with `systemctl enable --now sponsorblockcast`
 
 ## Configuration
 You can configure the following parameters by setting the appropriate enviroment values:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ First you will need a `docker-compose.yaml` file, such as the example included. 
 Run `sponsorblockcast` from a terminal or activate the service with `systemctl enable --now sponsorblockcast`
 
 ## Configuration
-You can configure the following parameters by setting the appropriate enviroment values:
+You can configure the following parameters by setting the appropriate environment values:
 * `SBCPOLLINTERVAL` - Time to wait between each polling of the Chromecasts' status (default=`1`)
 * `SBCSCANINTERVAL` - Time to wait between each scan for available Chromecast (default=`300`)
 * `SBCDIR` - Directory where temporary files are stored (default=`/tmp/sponsorblockcast`)
@@ -54,7 +54,7 @@ This will open a blank override file where you can specify Environment values li
 Environment="SBCPOLLINTERVAL=10"
 Environment="SBCSCANINTERVAL=100"
 Environment="SBCCATEGORIES=sponsor selfpromo"
-SBCYOUTUBEAPIKEY="your private API key"
+Environment="SBCYOUTUBEAPIKEY=<your private API key>"
 ```
 
 To modify the variables when running as a Docker container, you can add arguments to the `docker run` command like so:

--- a/sponsorblockcast.service
+++ b/sponsorblockcast.service
@@ -4,6 +4,7 @@ After=network.target
 [Service]
 ExecStart=/usr/bin/sponsorblockcast
 DynamicUser=yes
+Environment=HOME=/tmp/sponsorblockcast
 
 [Install]
 WantedBy=multi-user.target

--- a/sponsorblockcast.sh
+++ b/sponsorblockcast.sh
@@ -64,15 +64,18 @@ watch () {
         fi
       fi
 
-      get_segments "$video_id"
-      progress=$(echo "$status" | grep -oP 'remaining=\K[^s]+')
-      while read -r start end category; do
-        if [ "$(echo "($progress > $start) && ($progress < ($end - 5))" | bc)" -eq 1 ]
-        then
-          echo "Skipping $category from $start -> $end on $uuid"
-          go-chromecast -u "$uuid" seek-to "$end"
-        fi
-      done < "$video_id.segments"
+      if [ -n "$video_id" ]; then
+        get_segments "$video_id"
+        progress=$(echo "$status" | grep -oP 'remaining=\K[^s]+')
+        while read -r start end category; do
+          if [ "$(echo "($progress > $start) && ($progress < ($end - 5))" | bc)" -eq 1 ]
+          then
+            echo "Skipping $category from $start -> $end on $uuid"
+            go-chromecast -u "$uuid" seek-to "$end"
+          fi
+        done < "$video_id.segments"
+      fi
+
     fi
   done;
 }

--- a/sponsorblockcast.sh
+++ b/sponsorblockcast.sh
@@ -51,7 +51,7 @@ watch () {
   uuid=$1
   go-chromecast watch -u "$uuid" --interval "$SBCPOLLINTERVAL" \
   | while read -r status; do
-    if echo "$status" | grep -q "YouTube (PLAYING)"
+    if echo "$status" | grep -q "YouTube (PLAYING), title="
     then
       video_id=$(echo "$status" | grep -oP "id=\"\K[^\"]+")
       video_title=$(echo "$status" | grep -oP "title=\"\K[^\"]+")

--- a/sponsorblockcast.sh
+++ b/sponsorblockcast.sh
@@ -25,6 +25,7 @@ get_segments () {
   if [ -n "$id" ] && [ ! -f "$id".json ]
   then
     curl -fs --get "https://sponsor.ajay.app/api/skipSegments" --data "videoID=$id" --data "categories=$categories" > "$id".json
+    [ -s "$id".json ] && echo "$(jq '.[].segment[1]' "$id".json | wc -l) skippable segments found for video $id" || echo "No skippable segments found for video $id"
   fi
 }
 

--- a/sponsorblockcast.sh
+++ b/sponsorblockcast.sh
@@ -10,7 +10,7 @@ SBCCATEGORIES="${SBCCATEGORIES:-sponsor}"
 # Format categories for curl by quoting words, replacing spaces with commas and surrounding with brackets
 categories="[$(echo "$SBCCATEGORIES" | sed 's/[^ ]\+/"&"/g;s/\s/,/g')]"
 
-# Make sure the watch() subprocess gets killed if the parent script is terminated. 
+# Make sure the watch() subprocess gets killed if the parent script is terminated.
 trap "exit" INT TERM
 trap "kill 0" EXIT
 
@@ -24,14 +24,17 @@ get_segments () {
   id=$1
   if [ -n "$id" ] && [ ! -f "$id".json ]
   then
-    curl -fs --get "https://sponsor.ajay.app/api/skipSegments" --data "videoID=$id" --data "categories=$categories" > "$id".json
-    [ -s "$id".json ] && echo "$(jq '.[].segment[1]' "$id".json | wc -l) skippable segments found for video $id" || echo "No skippable segments found for video $id"
+    curl -fs --get "https://sponsor.ajay.app/api/skipSegments" \
+      --data "videoID=$id" --data "categories=$categories" > "$id".json
+    [ -s "$id".json ] \
+      && echo "$(jq '.[].segment[1]' "$id".json | wc -l) skippable segments found for video $id" \
+      || echo "No skippable segments found for video $id"
   fi
 }
 
 # Test if the input has changed since the last time this function was called
 has_variable_changed () {
-  if [ "$*" = "$prev_value" ] ; then
+  if [ "$*" = "$prev_value" ]; then
     return 1 # not changed
   else
     prev_value=$*
@@ -42,10 +45,13 @@ has_variable_changed () {
 # Fallback search method in case the Chromecast device fails to pass the videoId to go-chromecast
 get_videoID_by_API () {
   if [ -n "$SBCYOUTUBEAPIKEY" ] ; then
-    curl -fs --get "https://www.googleapis.com/youtube/v3/search" --data-urlencode "q=\"$video_artist\"+intitle:\"$video_title\"" --data-urlencode "maxResults=1" --data-urlencode "key=$SBCYOUTUBEAPIKEY" \
+    curl -fs --get "https://www.googleapis.com/youtube/v3/search" \
+      --data-urlencode "q=\"$video_artist\"+intitle:\"$video_title\"" \
+      --data-urlencode "maxResults=1" \
+      --data-urlencode "key=$SBCYOUTUBEAPIKEY" \
     | jq -j '.items[0].id.videoId'
   else
-    echo "Unable to identify Video ID. Try setting \$SBCYOUTUBEAPIKEY=\"your private Youtube API Key\" to enable fallback method."
+    echo 'Unable to identify Video ID. Try setting $SBCYOUTUBEAPIKEY="your private Youtube API Key" to enable fallback method.'
     return 1
   fi
 }
@@ -60,24 +66,22 @@ watch () {
       video_title=$(echo "$status" | grep -oP "title=\"\K[^\"]+")
       video_artist=$(echo "$status" | grep -oP "artist=\"\K[^\"]+")
 
-      if [ -z "$video_id" ]
-      then
-        if has_variable_changed "$video_title $video_artist"
-          # Avoid repeating the API search unless the playing video has changed.
-        then
+      if [ -z "$video_id" ]; then
+        # Avoid repeating the API search unless the playing video has changed.
+        if has_variable_changed "$video_title $video_artist"; then
           video_id="$(get_videoID_by_API)" && prev_video_id="$video_id"
         else
           video_id="$prev_video_id"
         fi
       fi
 
-      if [ -n "$video_id" ]; then # Only try to continue if the video has been identified successfully
+      # Only try to continue if the video has been identified successfully
+      if [ -n "$video_id" ]; then
         get_segments "$video_id"
         progress=$(echo "$status" | grep -oP 'remaining=\K[^s]+')
         jq --raw-output '.[] | (.segment|map_values(tostring)|join(" ")) + " " + .category' "$video_id".json 2> /dev/null |\
         while read -r start end category; do
-          if [ "$(echo "($progress > $start) && ($progress < ($end - 5))" | bc)" -eq 1 ]
-          then
+          if [ "$(echo "($progress > $start) && ($progress < ($end - 5))" | bc)" -eq 1 ]; then
             echo "Skipping $category from $start -> $end on $uuid"
             go-chromecast -u "$uuid" seek-to "$end"
           fi
@@ -106,7 +110,8 @@ do
   scan_chromecasts
   while read -r uuid; do
     uuid_var="sbc$uuid" # Create a dynamically named pid variable for each $uuid
-    if [ -z "$(expand "$uuid_var")" ] || ! pid_exists "$(expand "$uuid_var")" # If the pid variable is empty or the pid does not exist; prevents duplicate watch subprocesses
+    # If the pid variable is empty or the pid does not exist; prevents duplicate watch subprocesses
+    if [ -z "$(expand "$uuid_var")" ] || ! pid_exists "$(expand "$uuid_var")"
     then
       watch "$uuid" & # Watch in the background
       eval "$uuid_var=$!" # Save the pid into the variable for each $uuid

--- a/sponsorblockcast.sh
+++ b/sponsorblockcast.sh
@@ -39,7 +39,7 @@ has_variable_changed () {
 # Fallback search method in case the Chromecast device fails to pass the videoId to go-chromecast
 get_videoID_by_API () {
   if [ -n "$SBCYOUTUBEAPIKEY" ] ; then
-    curl -fs --get "https://www.googleapis.com/youtube/v3/search" --data-urlencode "q=\"$video_artist\" \"intitle:\"$video_title\"" --data-urlencode "maxResults=1" --data-urlencode "key=$SBCYOUTUBEAPIKEY" \
+    curl -fs --get "https://www.googleapis.com/youtube/v3/search" --data-urlencode "q=\"$video_artist\"+intitle:\"$video_title\"" --data-urlencode "maxResults=1" --data-urlencode "key=$SBCYOUTUBEAPIKEY" \
     | jq -j '.items[0].id.videoId'
   else
     echo "Unable to identify Video ID. Try setting \$SBCYOUTUBEAPIKEY=\"your private Youtube API Key\" to enable fallback method."

--- a/sponsorblockcast.sh
+++ b/sponsorblockcast.sh
@@ -12,10 +12,12 @@ categories="[$(echo "$SBCCATEGORIES" | sed 's/[^ ]\+/"&"/g;s/\s/,/g')]"
 trap "exit" INT TERM
 trap "kill 0" EXIT
 
+# Create and cleanup temporary directory
 [ -e "$SBCDIR" ] && rm -r "$SBCDIR"
 mkdir "$SBCDIR" || exit 1
 cd    "$SBCDIR" || exit 1
 
+# Download skippable segments data from SponsorBlock
 get_segments () {
   id=$1
   if [ -n "$id" ] && [ ! -f "$id".json ]
@@ -24,6 +26,7 @@ get_segments () {
   fi
 }
 
+# Test if the input has changed since the last time this function was called
 has_variable_changed () {
   if [ "$*" = "$prev_value" ] ; then
     return 1 # not changed
@@ -33,6 +36,7 @@ has_variable_changed () {
   fi
 }
 
+# Fallback search method in case the Chromecast device fails to pass the videoId to go-chromecast
 get_videoID_by_API () {
   if [ -n "$SBCYOUTUBEAPIKEY" ] ; then
     curl -fs --get "https://www.googleapis.com/youtube/v3/search" --data-urlencode "q=\"$video_artist\" \"intitle:\"$video_title\"" --data-urlencode "maxResults=1" --data-urlencode "key=$SBCYOUTUBEAPIKEY" \
@@ -56,6 +60,7 @@ watch () {
       if [ -z "$video_id" ]
       then
         if has_variable_changed "$video_title $video_artist"
+          # Avoid repeating the API search unless the playing video has changed.
         then
           video_id="$(get_videoID_by_API)" && prev_video_id="$video_id"
         else
@@ -63,7 +68,7 @@ watch () {
         fi
       fi
 
-      if [ -n "$video_id" ]; then
+      if [ -n "$video_id" ]; then # Only try to continue if the video has been identified successfully
         get_segments "$video_id"
         progress=$(echo "$status" | grep -oP 'remaining=\K[^s]+')
         jq --raw-output '.[] | (.segment|map_values(tostring)|join(" ")) + " " + .category' "$video_id".json 2> /dev/null |\
@@ -97,12 +102,12 @@ while :
 do
   scan_chromecasts
   while read -r uuid; do
-    uuid_var="sbc$uuid"
-    if [ -z "$(expand "$uuid_var")" ] || ! pid_exists "$(expand "$uuid_var")"
+    uuid_var="sbc$uuid" # Create a dynamically named pid variable for each $uuid
+    if [ -z "$(expand "$uuid_var")" ] || ! pid_exists "$(expand "$uuid_var")" # If the pid variable is empty or the pid does not exist; prevents duplicate watch subprocesses
     then
-      watch "$uuid" &
-      eval "$uuid_var=$!"
-      echo watching "$uuid", pid="$(expand "$uuid_var")"
+      watch "$uuid" & # Watch in the background
+      eval "$uuid_var=$!" # Save the pid into the variable for each $uuid
+      echo watching "$uuid", pid="$(expand "$uuid_var")" # Log
     fi
   done < devices
   sleep "$SBCSCANINTERVAL"

--- a/sponsorblockcast.sh
+++ b/sponsorblockcast.sh
@@ -63,10 +63,10 @@ watch () {
     if echo "$status" | grep -q "YouTube (PLAYING), title="
     then
       video_id=$(echo "$status" | grep -oP "id=\"\K[^\"]+")
-      video_title=$(echo "$status" | grep -oP "title=\"\K[^\"]+")
-      video_artist=$(echo "$status" | grep -oP "artist=\"\K[^\"]+")
 
       if [ -z "$video_id" ]; then
+        video_title=$(echo "$status" | grep -oP "title=\"\K[^\"]+")
+        video_artist=$(echo "$status" | grep -oP "artist=\"\K[^\"]+")
         # Avoid repeating the API search unless the playing video has changed.
         if has_variable_changed "$video_title $video_artist"; then
           video_id="$(get_videoID_by_API)" && prev_video_id="$video_id"

--- a/sponsorblockcast.sh
+++ b/sponsorblockcast.sh
@@ -36,8 +36,14 @@ watch () {
       video_artist=$(echo "$status" | grep -oP "artist=\"\K[^\"]+")
       if [ -z "$video_id" ]
       then
-        echo "Video ID missing. Attempting to identify video by search."
-        video_id=$(curl --get "https://www.googleapis.com/youtube/v3/search" --data-urlencode "q=$video_title\ $video_artist" --data-urlencode "maxResults=1" --data-urlencode "key=$SBCYOUTUBEAPIKEY" | jq '.items[0].id.videoId')
+        if [ "$prev_video" != "$video_title $video_artist" ]
+        then
+          video_id="$(curl -fs --get "https://www.googleapis.com/youtube/v3/search" --data-urlencode "q=$video_title $video_artist" --data-urlencode "maxResults=1" --data-urlencode "key=$SBCYOUTUBEAPIKEY" | jq -j '.items[0].id.videoId')"
+          prev_video="$video_title $video_artist"
+          prev_video_id="$video_id"
+        else
+          video_id="$prev_video_id"
+        fi
       fi
       get_segments "$video_id"
       progress=$(echo "$status" | grep -oP 'remaining=\K[^s]+')

--- a/sponsorblockcast.sh
+++ b/sponsorblockcast.sh
@@ -27,7 +27,7 @@ get_segments () {
 
 watch () {
   uuid=$1
-  go-chromecast watch -u "$uuid" --interval 1 \
+  go-chromecast watch -u "$uuid" --interval "$SBCPOLLINTERVAL" \
   | while read -r status; do
     if echo "$status" | grep -q "YouTube (PLAYING)"
     then

--- a/sponsorblockcast.sh
+++ b/sponsorblockcast.sh
@@ -5,8 +5,8 @@ SBCSCANINTERVAL="${SBCSCANINTERVAL:-300}"
 SBCDIR="${SBCDIR:-/tmp/sponsorblockcast}"
 SBCCATEGORIES="${SBCCATEGORIES:-sponsor}"
 
-# Format categories for curl by quoting words, replacing spaces with commas and surrounding with escaped brackets
-categories="\\[$(echo "$SBCCATEGORIES" | sed 's/[^ ]\+/"&"/g;s/\s/,/g')\\]"
+# Format categories for curl by quoting words, replacing spaces with commas and surrounding with brackets
+categories="[$(echo "$SBCCATEGORIES" | sed 's/[^ ]\+/"&"/g;s/\s/,/g')]"
 
 # Make sure the watch() subprocess gets killed if the parent script is terminated. 
 trap "exit" INT TERM
@@ -20,7 +20,7 @@ get_segments () {
   id=$1
   if [ -n "$id" ] && [ ! -f "$id".segments ]
   then
-    curl -fs "https://sponsor.ajay.app/api/skipSegments?videoID=$id&categories=$categories" |\
+    curl -fs --get "https://sponsor.ajay.app/api/skipSegments" --data "videoID=$id" --data "categories=$categories" |\
     jq -r '.[] | (.segment|map_values(tostring)|join(" ")) + " " + .category' > "$id.segments"
   fi
 }

--- a/sponsorblockcast.sh
+++ b/sponsorblockcast.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+[ "$SBCDEBUG" = true ] && set -x
+
 SBCPOLLINTERVAL="${SBCPOLLINTERVAL:-1}"
 SBCSCANINTERVAL="${SBCSCANINTERVAL:-300}"
 SBCDIR="${SBCDIR:-/tmp/sponsorblockcast}"

--- a/sponsorblockcast.sh
+++ b/sponsorblockcast.sh
@@ -34,7 +34,7 @@ watch () {
       video_id=$(echo "$status" | grep -oP "id=\"\K[^\"]+")
       video_title=$(echo "$status" | grep -oP "title=\"\K[^\"]+")
       video_artist=$(echo "$status" | grep -oP "artist=\"\K[^\"]+")
-      if [ -z "$video_id" ]
+      if [ -z "$video_id" ] && [ -n "$SBCYOUTUBEAPIKEY" ]
       then
         if [ "$prev_video" != "$video_title $video_artist" ]
         then

--- a/sponsorblockcast.sh
+++ b/sponsorblockcast.sh
@@ -38,7 +38,7 @@ watch () {
       then
         if [ "$prev_video" != "$video_title $video_artist" ]
         then
-          video_id="$(curl -fs --get "https://www.googleapis.com/youtube/v3/search" --data-urlencode "q=$video_title $video_artist" --data-urlencode "maxResults=1" --data-urlencode "key=$SBCYOUTUBEAPIKEY" | jq -j '.items[0].id.videoId')"
+          video_id="$(curl -fs --get "https://www.googleapis.com/youtube/v3/search" --data-urlencode "q=\"$video_artist\" \"intitle:\"$video_title\"" --data-urlencode "maxResults=1" --data-urlencode "key=$SBCYOUTUBEAPIKEY" | jq -j '.items[0].id.videoId')"
           prev_video="$video_title $video_artist"
           prev_video_id="$video_id"
         else


### PR DESCRIPTION
On newer Chromecast devices which don't return the `videoID` to `go-chromecast`, attempt to identify it using an API search query. Not guaranteed to get it right.
Requires an API key.
Fixes [nichobi/sponsorblockcast#16](https://github.com/nichobi/sponsorblockcast/issues/16)

TODO: Needs error handling, in case an API query is attempted but fails.
TODO: Needs some validation to confirm back that it's identified the right `videoID`. Perhaps by comparing the duration returned by `go-chromecast` to the `videoDuration` in the `sponsorblock` database.
TODO: Could scrape a non-API Youtube search as a secondary fallback option if the API query fails. This would be less robust but doesn't require an API key.