### PR TITLE
Capitalise T in YouTube

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # sponsorblockcast
-A POSIX shell script that skips sponsored Youtube content on all local Chromecasts, using the [SponsorBlock](https://github.com/ajayyy/SponsorBlock) API. It was inspired by [CastBlock](https://github.com/stephen304/castblock) but written from scratch to avoid some of its pitfalls (see [Differences from CastBlock](#differences-from-castblock))
+A POSIX shell script that skips sponsored YouTube content on all local Chromecasts, using the [SponsorBlock](https://github.com/ajayyy/SponsorBlock) API. It was inspired by [CastBlock](https://github.com/stephen304/castblock) but written from scratch to avoid some of its pitfalls (see [Differences from CastBlock](#differences-from-castblock))
 
 Care was taken to ensure it's fully POSIX-compatible, so it can run on lighter shells such as [Dash](https://wiki.archlinux.org/index.php/Dash).
 


### PR DESCRIPTION
Capitalise T in YouTube to match official name and the other occurrence in the readme.