### PR TITLE
Skip Youtube ads when skip button appears

### DIFF
--- a/sponsorblockcast.sh
+++ b/sponsorblockcast.sh
@@ -89,6 +89,13 @@ watch () {
       fi
 
     fi
+
+    supported_cmd=$(echo "$status" | grep -oP "\"supportedMediaCommands\":\K[0-9]+")
+    if [ -n "$supported_cmd" -a $(( supported_cmd & 0x2 )) -eq $(( 0x0 )) ]; then
+      #Ad is skippable
+      echo "Skipping skippable ad"
+      go-chromecast -u "$uuid" skipad
+    fi
   done;
 }
 


### PR DESCRIPTION
When a skippable Youtube ad is playing the Chromecast's `supportedMediaCommand` field will indicate that the skip ad button is available. [Google's docs](https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages#.RepeatMode) aren't very helpful here but through trial and error I found the second bit being 0 indicates the skip button is up. 

So you do a bitwise `&` with `0x2` (`10`) since the second bit is what we care about. If the result of that is a 0 the second bit was a 0 and you can skip the ad.
