### PR TITLE
use gnu tools on macos

### DIFF
--- a/sponsorblockcast.sh
+++ b/sponsorblockcast.sh
@@ -7,6 +7,18 @@ SBCSCANINTERVAL="${SBCSCANINTERVAL:-300}"
 SBCDIR="${SBCDIR:-/tmp/sponsorblockcast}"
 SBCCATEGORIES="${SBCCATEGORIES:-sponsor}"
 
+sysname=$(uname -s)
+if [ "$sysname" = "Darwin" ]; then
+  if which ggrep gsed > /dev/null; then
+    alias grep=ggrep
+    alias sed=gsed
+    shopt -s expand_aliases
+  else
+    echo >&2 $0 requires GNU grep and sed. Run \`brew install grep gnu-sed\`.
+    exit 1
+  fi
+fi
+
 # Format categories for curl by quoting words, replacing spaces with commas and surrounding with brackets
 categories="[$(echo "$SBCCATEGORIES" | sed 's/[^ ]\+/"&"/g;s/\s/,/g')]"
 

--- a/sponsorblockcast.sh
+++ b/sponsorblockcast.sh
@@ -12,9 +12,8 @@ if [ "$sysname" = "Darwin" ]; then
   if which ggrep gsed > /dev/null; then
     alias grep=ggrep
     alias sed=gsed
-    shopt -s expand_aliases
   else
-    echo >&2 $0 requires GNU grep and sed. Run \`brew install grep gnu-sed\`.
+    echo >&2 "$0" requires GNU grep and sed. Run \`brew install grep gnu-sed\`.
     exit 1
   fi
 fi


### PR DESCRIPTION
SBC doesn't work with BSD tools. This is a small preamble for running on macos. It does the following:

1. Look for GNU `grep` and `sed` installed by homebrew as `ggrep` and `gsed`.
2. If not found, prompt and exit.
3. Otherwise, alias `grep` and `sed`, then proceed as normal.
