### PR TITLE
Updated the build even more

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -1,27 +1,42 @@
 name: build-and-push-image
 
 on:
+  schedule:
+    - cron: '0 0 * * *'  # Schedule to run once every day
   push:
     branches:
       - main
+
+env:
+  CURRENT_RELEASE: v0.3.1
 
 jobs:
   build-multi-arch-image:
     name: Build multi-arch Docker image
     runs-on: ubuntu-latest
     steps:
+      - name: Check for new release
+        id: check_release
+        run: |
+          LATEST_RELEASE=$(curl -sL https://api.github.com/repos/vishen/go-chromecast/releases/latest | jq -r '.tag_name')
+          echo "::set-output name=release::$LATEST_RELEASE"
+
       - name: Checkout
+        if: steps.check_release.outputs.release != env.CURRENT_RELEASE
         uses: actions/checkout@v2
 
       - name: Set up QEMU
+        if: steps.check_release.outputs.release != env.CURRENT_RELEASE
         uses: docker/setup-qemu-action@v1
         
       - name: Set up Docker Buildx
+        if: steps.check_release.outputs.release != env.CURRENT_RELEASE
         uses: docker/setup-buildx-action@v1
         with:
           install: true
 
       - name: Login to GitHub Container Registry
+        if: steps.check_release.outputs.release != env.CURRENT_RELEASE
         uses: docker/login-action@v1 
         with:
           registry: ghcr.io
@@ -29,6 +44,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
+        if: steps.check_release.outputs.release != env.CURRENT_RELEASE
         uses: docker/build-push-action@v2
         with:
           push: true 

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -38,7 +38,6 @@ jobs:
             echo "version_changed=true" >> $GITHUB_ENV
             sed -i "s/ENV CHROMECASTGOVERSION=.*/ENV CHROMECASTGOVERSION=${{ env.LATEST_CHROMECASTGOVERSION }}/" Dockerfile
           fi
-          cat Dockerfile
           echo "PREVIOUS_CHROMECASTGOVERSION=${{ env.CURRENT_CHROMECASTGOVERSION }}" >> $GITHUB_ENV
 
       - name: Set up QEMU

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -19,11 +19,10 @@ jobs:
         id: check_release
         run: |
           LATEST_RELEASE=$(curl -sL https://api.github.com/repos/vishen/go-chromecast/releases/latest | jq -r '.tag_name')
-          echo "release=$LATEST_RELEASE" >> $GITHUB_ENV
-          echo "CURRENT_RELEASE=${{ steps.check_release.outputs.release }}" >> $GITHUB_ENV
-
+          echo "LATEST_RELEASE=$LATEST_RELEASE" >> $GITHUB_ENV
+  
       - name: Checkout
-        if: steps.check_release.outputs.release != env.CURRENT_RELEASE
+        if: env.LATEST_RELEASE != env.CURRENT_RELEASE
         uses: actions/checkout@v2
 
       - name: Set up QEMU

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get current go-chromecast version from Dockerfile
         id: get-current-version
@@ -41,18 +41,18 @@ jobs:
           echo "PREVIOUS_CHROMECASTGOVERSION=${{ env.CURRENT_CHROMECASTGOVERSION }}" >> $GITHUB_ENV
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2.1.0
         if: ${{ env.VERSION_CHANGED == 'true' }}
         
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2.5.0
         with:
           install: true
         if: ${{ env.VERSION_CHANGED == 'true' }}
 
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -61,7 +61,7 @@ jobs:
 
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses:  docker/build-push-action@v4.0.0
         with:
           push: true 
           tags: ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -61,6 +61,7 @@ jobs:
         uses: docker/build-push-action@v4.0.0
         with:
           push: true 
+          context: .
           tags: ghcr.io/${{ github.repository }}:latest
           platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6
           file: ./Dockerfile

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  CURRENT_RELEASE: v0.2.12
+  CURRENT_RELEASE_FILE: release.txt
 
 jobs:
   build-multi-arch-image:
@@ -20,9 +20,17 @@ jobs:
         run: |
           LATEST_RELEASE=$(curl -sL https://api.github.com/repos/vishen/go-chromecast/releases/latest | jq -r '.tag_name')
           echo "LATEST_RELEASE=$LATEST_RELEASE" >> $GITHUB_ENV
+
+          CURRENT_RELEASE=$(cat $CURRENT_RELEASE_FILE)
+          echo "CURRENT_RELEASE=$CURRENT_RELEASE"
+  
           if [[ "$LATEST_RELEASE" != "$CURRENT_RELEASE" ]]; then
-            echo "CURRENT_RELEASE=$LATEST_RELEASE" >> $GITHUB_ENV
-          fi  
+            echo "$LATEST_RELEASE" > $CURRENT_RELEASE_FILE
+            echo "Updated CURRENT_RELEASE to $LATEST_RELEASE"
+          else
+            echo "No new release found. CURRENT_RELEASE=$CURRENT_RELEASE"
+          fi
+      
       - name: Checkout
         if: env.LATEST_RELEASE != env.CURRENT_RELEASE
         uses: actions/checkout@v2

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Get current go-chromecast version from Dockerfile
         id: get-current-version
         run: |
-          CURRENT_CHROMECASTGOVERSION=$(grep -oP '(?<=CHROMECASTGOVERSION=).*' Dockerfile)
+          CURRENT_CHROMECASTGOVERSION=$(grep -oP '(?<=CHROMECASTGOVERSION=).*' ./Dockerfile)
           echo "CURRENT_CHROMECASTGOVERSION=$CURRENT_CHROMECASTGOVERSION" >> $GITHUB_ENV
 
       - name: Get latest go-chromecast version
@@ -39,13 +39,6 @@ jobs:
             sed -i "s/ENV CHROMECASTGOVERSION=.*/ENV CHROMECASTGOVERSION=${{ env.LATEST_CHROMECASTGOVERSION }}/" ./Dockerfile
           fi
       
-      - name: Upload modified Dockerfile as artifact
-        uses: actions/upload-artifact@v3
-        if: ${{ env.VERSION_CHANGED == 'true' }}
-        with:
-          name: Dockerfile
-          path: ./Dockerfile
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2.1.0
         if: ${{ env.VERSION_CHANGED == 'true' }}
@@ -64,18 +57,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ env.VERSION_CHANGED == 'true' }}
 
-      - name: Download modified Dockerfile artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: Dockerfile
-        if: ${{ env.VERSION_CHANGED == 'true' }}
-
       - name: Build and push
-        uses:  docker/build-push-action@v4.0.0
+        uses: docker/build-push-action@v4.0.0
         with:
           push: true 
           tags: ghcr.io/${{ github.repository }}:latest
           platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6
-          dockerfile: /build/Dockerfile
+          dockerfile: Dockerfile
         if: ${{ env.VERSION_CHANGED == 'true' }}
 

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -38,7 +38,13 @@ jobs:
             echo "VERSION_CHANGED=true" >> $GITHUB_ENV
             sed -i "s/ENV CHROMECASTGOVERSION=.*/ENV CHROMECASTGOVERSION=${{ env.LATEST_CHROMECASTGOVERSION }}/" ./Dockerfile
           fi
-          echo "PREVIOUS_CHROMECASTGOVERSION=${{ env.CURRENT_CHROMECASTGOVERSION }}" >> $GITHUB_ENV
+      
+      - name: Upload modified Dockerfile as artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ env.VERSION_CHANGED == 'true' }}
+        with:
+          name: modified-dockerfile
+          path: ./modified-dockerfile
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2.1.0

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -32,13 +32,13 @@ jobs:
         run: |
           if [[ "${{ env.CURRENT_CHROMECASTGOVERSION }}" == "${{ env.LATEST_CHROMECASTGOVERSION }}" ]]; then
             echo "No new version available. Skipping Dockerfile update."
-            echo "::set-output name=version_changed::false"
+            echo "version_changed=false" >> $GITHUB_ENV
           else
             echo "New version available. Updating Dockerfile."
-            echo "::set-output name=version_changed::true"
+            echo "version_changed=true" >> $GITHUB_ENV
             sed -i "s/ENV CHROMECASTGOVERSION=.*/ENV CHROMECASTGOVERSION=${{ env.LATEST_CHROMECASTGOVERSION }}/" Dockerfile
           fi
-
+          cat Dockerfile
           echo "PREVIOUS_CHROMECASTGOVERSION=${{ env.CURRENT_CHROMECASTGOVERSION }}" >> $GITHUB_ENV
 
       - name: Set up QEMU

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -76,5 +76,6 @@ jobs:
           push: true 
           tags: ghcr.io/${{ github.repository }}:latest
           platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6
+          dockerfile: ./Dockerfile
         if: ${{ env.VERSION_CHANGED == 'true' }}
 

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  CURRENT_RELEASE: v0.3.1
+  CURRENT_RELEASE: v0.2.12
 
 jobs:
   build-multi-arch-image:
@@ -20,7 +20,9 @@ jobs:
         run: |
           LATEST_RELEASE=$(curl -sL https://api.github.com/repos/vishen/go-chromecast/releases/latest | jq -r '.tag_name')
           echo "LATEST_RELEASE=$LATEST_RELEASE" >> $GITHUB_ENV
-  
+          if [[ "$LATEST_RELEASE" != "$CURRENT_RELEASE" ]]; then
+            echo "CURRENT_RELEASE=$LATEST_RELEASE" >> $GITHUB_ENV
+          fi  
       - name: Checkout
         if: env.LATEST_RELEASE != env.CURRENT_RELEASE
         uses: actions/checkout@v2

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -56,7 +56,6 @@ jobs:
           install: true
         if: ${{ env.VERSION_CHANGED == 'true' }}
 
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2.1.0
         with:
@@ -65,6 +64,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ env.VERSION_CHANGED == 'true' }}
 
+      - name: Download modified Dockerfile artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: modified-dockerfile
+        if: ${{ env.VERSION_CHANGED == 'true' }}
 
       - name: Build and push
         uses:  docker/build-push-action@v4.0.0
@@ -72,6 +76,5 @@ jobs:
           push: true 
           tags: ghcr.io/${{ github.repository }}:latest
           platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6
-          dockerfile: ./Dockerfile # specify the path to your Dockerfile here
         if: ${{ env.VERSION_CHANGED == 'true' }}
 

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -57,6 +57,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ env.VERSION_CHANGED == 'true' }}
 
+      - name: Print downloaded Dockerfile
+        run: cat Dockerfile
+        if: ${{ env.VERSION_CHANGED == 'true' }}
+
+
       - name: Build and push
         uses: docker/build-push-action@v4.0.0
         with:

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -19,7 +19,7 @@ jobs:
         id: check_release
         run: |
           LATEST_RELEASE=$(curl -sL https://api.github.com/repos/vishen/go-chromecast/releases/latest | jq -r '.tag_name')
-          echo "::set-output name=release::$LATEST_RELEASE"
+          echo "release=$LATEST_RELEASE" >> $GITHUB_ENV
 
       - name: Update CURRENT_RELEASE
         if: steps.check_release.outputs.release != env.CURRENT_RELEASE

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -43,8 +43,8 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ env.VERSION_CHANGED == 'true' }}
         with:
-          name: modified-dockerfile
-          path: ./modified-dockerfile
+          name: Dockerfile
+          path: ./Dockerfile
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2.1.0
@@ -67,7 +67,7 @@ jobs:
       - name: Download modified Dockerfile artifact
         uses: actions/download-artifact@v3
         with:
-          name: modified-dockerfile
+          name: Dockerfile
         if: ${{ env.VERSION_CHANGED == 'true' }}
 
       - name: Build and push

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           LATEST_RELEASE=$(curl -sL https://api.github.com/repos/vishen/go-chromecast/releases/latest | jq -r '.tag_name')
           echo "LATEST_RELEASE=$LATEST_RELEASE" >> $GITHUB_ENV
-
+          touch release.txt
           CURRENT_RELEASE=$(cat $CURRENT_RELEASE_FILE)
           echo "CURRENT_RELEASE=$CURRENT_RELEASE"
   

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -36,7 +36,7 @@ jobs:
           else
             echo "New version available. Updating Dockerfile."
             echo "VERSION_CHANGED=true" >> $GITHUB_ENV
-            sed -i "s/ENV CHROMECASTGOVERSION=.*/ENV CHROMECASTGOVERSION=${{ env.LATEST_CHROMECASTGOVERSION }}/" /build/Dockerfile
+            sed -i "s/ENV CHROMECASTGOVERSION=.*/ENV CHROMECASTGOVERSION=${{ env.LATEST_CHROMECASTGOVERSION }}/" ./Dockerfile
           fi
       
       - name: Upload modified Dockerfile as artifact

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -36,7 +36,7 @@ jobs:
           else
             echo "New version available. Updating Dockerfile."
             echo "VERSION_CHANGED=true" >> $GITHUB_ENV
-            sed -i "s/ENV CHROMECASTGOVERSION=.*/ENV CHROMECASTGOVERSION=${{ env.LATEST_CHROMECASTGOVERSION }}/" Dockerfile
+            sed -i "s/ENV CHROMECASTGOVERSION=.*/ENV CHROMECASTGOVERSION=${{ env.LATEST_CHROMECASTGOVERSION }}/" ./Dockerfile
           fi
           echo "PREVIOUS_CHROMECASTGOVERSION=${{ env.CURRENT_CHROMECASTGOVERSION }}" >> $GITHUB_ENV
 

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -42,13 +42,14 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
-        if: ${{ steps.check-version-and-update-dockerfile.outputs.version_changed == 'true' }}
+        if: ${{ steps.check-version-and-update-dockerfile.outputs.version_changed == true }}
         
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
           install: true
-        if: ${{ steps.check-version-and-update-dockerfile.outputs.version_changed == 'true' }}
+        if: ${{ steps.check-version-and-update-dockerfile.outputs.version_changed == true }}
+
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1 
@@ -56,7 +57,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ steps.check-version-and-update-dockerfile.outputs.version_changed == 'true' }}
+        if: ${{ steps.check-version-and-update-dockerfile.outputs.version_changed == true }}
+
 
       - name: Build and push
         uses: docker/build-push-action@v2
@@ -64,4 +66,5 @@ jobs:
           push: true 
           tags: ghcr.io/${{ github.repository }}:latest
           platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6
-        if: ${{ steps.check-version-and-update-dockerfile.outputs.version_changed == 'true' }}
+        if: ${{ steps.check-version-and-update-dockerfile.outputs.version_changed == true }}
+

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -42,13 +42,13 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
-        if: ${{ steps.check-version-and-update-dockerfile.outputs.version_changed == true }}
+        if: ${{ env.VERSION_CHANGED == 'true' }}
         
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
           install: true
-        if: ${{ steps.check-version-and-update-dockerfile.outputs.version_changed == true }}
+        if: ${{ env.VERSION_CHANGED == 'true' }}
 
 
       - name: Login to GitHub Container Registry
@@ -57,7 +57,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ steps.check-version-and-update-dockerfile.outputs.version_changed == true }}
+        if: ${{ env.VERSION_CHANGED == 'true' }}
 
 
       - name: Build and push
@@ -66,5 +66,5 @@ jobs:
           push: true 
           tags: ghcr.io/${{ github.repository }}:latest
           platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6
-        if: ${{ steps.check-version-and-update-dockerfile.outputs.version_changed == true }}
+        if: ${{ env.VERSION_CHANGED == 'true' }}
 

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -36,7 +36,7 @@ jobs:
           else
             echo "New version available. Updating Dockerfile."
             echo "VERSION_CHANGED=true" >> $GITHUB_ENV
-            sed -i "s/ENV CHROMECASTGOVERSION=.*/ENV CHROMECASTGOVERSION=${{ env.LATEST_CHROMECASTGOVERSION }}/" ./Dockerfile
+            sed -i "s/ENV CHROMECASTGOVERSION=.*/ENV CHROMECASTGOVERSION=${{ env.LATEST_CHROMECASTGOVERSION }}/" ./build/Dockerfile
           fi
       
       - name: Upload modified Dockerfile as artifact
@@ -76,6 +76,6 @@ jobs:
           push: true 
           tags: ghcr.io/${{ github.repository }}:latest
           platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6
-          dockerfile: ./Dockerfile
+          dockerfile: ./build/Dockerfile
         if: ${{ env.VERSION_CHANGED == 'true' }}
 

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  CURRENT_RELEASE: v0.3.1
+  CURRENT_RELEASE: v0.2.12
 
 jobs:
   build-multi-arch-image:

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -15,13 +15,40 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Get current go-chromecast version from Dockerfile
+        id: get-current-version
+        run: |
+          CURRENT_CHROMECASTGOVERSION=$(grep -oP '(?<=CHROMECASTGOVERSION=).*' Dockerfile)
+          echo "CURRENT_CHROMECASTGOVERSION=$CURRENT_CHROMECASTGOVERSION" >> $GITHUB_ENV
+
+      - name: Get latest go-chromecast version
+        id: get-latest-version
+        run: |
+          LATEST_VERSION=$(curl -s "https://api.github.com/repos/vishen/go-chromecast/releases/latest" | jq -r '.tag_name')
+          echo "LATEST_CHROMECASTGOVERSION=$LATEST_VERSION" >> $GITHUB_ENV
+
+      - name: Check if version is newer and update Dockerfile
+        id: check-version-and-update-dockerfile
+        run: |
+          if [[ "${{ env.CURRENT_CHROMECASTGOVERSION }}" == "${{ env.LATEST_CHROMECASTGOVERSION }}" ]]; then
+            echo "No new version available. Skipping build."
+            echo "::set-output name=version_changed::false"
+          else
+            echo "New version available. Updating Dockerfile."
+            echo "::set-output name=version_changed::true"
+            sed -i "s/ENV CHROMECASTGOVERSION=.*/ENV CHROMECASTGOVERSION=${{ env.LATEST_CHROMECASTGOVERSION }}/" Dockerfile
+          
+          echo "PREVIOUS_CHROMECASTGOVERSION=${{ env.CURRENT_CHROMECASTGOVERSION }}" >> $GITHUB_ENV
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
+        if: steps.check-version-and-update-dockerfile.outputs.version_changed == 'true'
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
           install: true
+        if: steps.check-version-and-update-dockerfile.outputs.version_changed == 'true'
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1 
@@ -29,27 +56,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get current go-chromecast version
-        id: get-chromecast-version
-        run: |
-          CHROMECASTGOVERSION=$(wget -qO- https://api.github.com/repos/vishen/go-chromecast/releases/latest | jq -r '.tag_name')
-          echo "CHROMECASTGOVERSION=$CHROMECASTGOVERSION" >> $GITHUB_ENV
-
-      - name: Check if version is newer
-        id: check-version
-        run: |
-          if [[ "${{ env.CHROMECASTGOVERSION }}" == "${{ secrets.CURRENT_CHROMECASTGOVERSION }}" ]]; then
-            echo "::set-output name=build_required::false"
-          else
-            echo "::set-output name=build_required::true"
-          fi
+        if: steps.check-version-and-update-dockerfile.outputs.version_changed == 'true'
 
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
-          push: ${{ steps.check-version.outputs.build_required }}
+          push: true 
           tags: ghcr.io/${{ github.repository }}:latest
           platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6
-        env:
-          CHROMECASTGOVERSION: ${{ env.CHROMECASTGOVERSION }}
+        if: steps.check-version-and-update-dockerfile.outputs.version_changed == 'true'

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -36,7 +36,7 @@ jobs:
           else
             echo "New version available. Updating Dockerfile."
             echo "VERSION_CHANGED=true" >> $GITHUB_ENV
-            sed -i "s/ENV CHROMECASTGOVERSION=.*/ENV CHROMECASTGOVERSION=${{ env.LATEST_CHROMECASTGOVERSION }}/" ./build/Dockerfile
+            sed -i "s/ENV CHROMECASTGOVERSION=.*/ENV CHROMECASTGOVERSION=${{ env.LATEST_CHROMECASTGOVERSION }}/" /build/Dockerfile
           fi
       
       - name: Upload modified Dockerfile as artifact
@@ -76,6 +76,6 @@ jobs:
           push: true 
           tags: ghcr.io/${{ github.repository }}:latest
           platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6
-          dockerfile: ./build/Dockerfile
+          dockerfile: /build/Dockerfile
         if: ${{ env.VERSION_CHANGED == 'true' }}
 

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -57,17 +57,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ env.VERSION_CHANGED == 'true' }}
 
-      - name: Print downloaded Dockerfile
-        run: cat Dockerfile
-        if: ${{ env.VERSION_CHANGED == 'true' }}
-
-
       - name: Build and push
         uses: docker/build-push-action@v4.0.0
         with:
           push: true 
           tags: ghcr.io/${{ github.repository }}:latest
           platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6
-          dockerfile: Dockerfile
+          file: ./Dockerfile
         if: ${{ env.VERSION_CHANGED == 'true' }}
 

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -20,10 +20,7 @@ jobs:
         run: |
           LATEST_RELEASE=$(curl -sL https://api.github.com/repos/vishen/go-chromecast/releases/latest | jq -r '.tag_name')
           echo "release=$LATEST_RELEASE" >> $GITHUB_ENV
-
-      - name: Update CURRENT_RELEASE
-        if: steps.check_release.outputs.release != env.CURRENT_RELEASE
-        run: echo "CURRENT_RELEASE=${{ steps.check_release.outputs.release }}" >> $GITHUB_ENV
+          echo "CURRENT_RELEASE=${{ steps.check_release.outputs.release }}" >> $GITHUB_ENV
 
       - name: Checkout
         if: steps.check_release.outputs.release != env.CURRENT_RELEASE

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -1,27 +1,15 @@
 name: build-and-push-image
 
 on:
-  schedule:
-    - cron: '0 0 * * *'  # Schedule to run once every day
   push:
     branches:
       - main
-
-env:
-  CURRENT_RELEASE: v0.3.1
 
 jobs:
   build-multi-arch-image:
     name: Build multi-arch Docker image
     runs-on: ubuntu-latest
     steps:
-      - name: Check for new release
-        id: check_release
-        run: |
-          LATEST_RELEASE=$(curl -sL https://api.github.com/repos/vishen/go-chromecast/releases/latest | jq -r '.tag_name')
-          echo "release=$LATEST_RELEASE" >> $GITHUB_ENV
-          echo "CURRENT_RELEASE=${{ steps.check_release.outputs.release }}" >> $GITHUB_ENV
-
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -31,13 +31,14 @@ jobs:
         id: check-version-and-update-dockerfile
         run: |
           if [[ "${{ env.CURRENT_CHROMECASTGOVERSION }}" == "${{ env.LATEST_CHROMECASTGOVERSION }}" ]]; then
-            echo "No new version available. Skipping build."
+            echo "No new version available. Skipping Dockerfile update."
             echo "::set-output name=version_changed::false"
           else
             echo "New version available. Updating Dockerfile."
             echo "::set-output name=version_changed::true"
             sed -i "s/ENV CHROMECASTGOVERSION=.*/ENV CHROMECASTGOVERSION=${{ env.LATEST_CHROMECASTGOVERSION }}/" Dockerfile
-          
+          fi
+
           echo "PREVIOUS_CHROMECASTGOVERSION=${{ env.CURRENT_CHROMECASTGOVERSION }}" >> $GITHUB_ENV
 
       - name: Set up QEMU

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -66,5 +66,6 @@ jobs:
           push: true 
           tags: ghcr.io/${{ github.repository }}:latest
           platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6
+          dockerfile: ./Dockerfile # specify the path to your Dockerfile here
         if: ${{ env.VERSION_CHANGED == 'true' }}
 

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  CURRENT_RELEASE: v0.2.12
+  CURRENT_RELEASE: v0.3.1
 
 jobs:
   build-multi-arch-image:
@@ -26,17 +26,17 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up QEMU
-        if: steps.check_release.outputs.release != env.CURRENT_RELEASE
+        if: env.LATEST_RELEASE != env.CURRENT_RELEASE
         uses: docker/setup-qemu-action@v1
         
       - name: Set up Docker Buildx
-        if: steps.check_release.outputs.release != env.CURRENT_RELEASE
+        if: env.LATEST_RELEASE != env.CURRENT_RELEASE
         uses: docker/setup-buildx-action@v1
         with:
           install: true
 
       - name: Login to GitHub Container Registry
-        if: steps.check_release.outputs.release != env.CURRENT_RELEASE
+        if: env.LATEST_RELEASE != env.CURRENT_RELEASE
         uses: docker/login-action@v1 
         with:
           registry: ghcr.io
@@ -44,7 +44,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        if: steps.check_release.outputs.release != env.CURRENT_RELEASE
+        if: env.LATEST_RELEASE != env.CURRENT_RELEASE
         uses: docker/build-push-action@v2
         with:
           push: true 

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -1,8 +1,6 @@
 name: build-and-push-image
 
 on:
-  schedule:
-    - cron: '0 0 * * *'  # Schedule to run once every day
   push:
     branches:
       - main
@@ -15,39 +13,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Get current go-chromecast version from Dockerfile
-        id: get-current-version
-        run: |
-          CURRENT_CHROMECASTGOVERSION=$(grep -oP '(?<=CHROMECASTGOVERSION=).*' ./Dockerfile)
-          echo "CURRENT_CHROMECASTGOVERSION=$CURRENT_CHROMECASTGOVERSION" >> $GITHUB_ENV
-
-      - name: Get latest go-chromecast version
-        id: get-latest-version
-        run: |
-          LATEST_VERSION=$(curl -s "https://api.github.com/repos/vishen/go-chromecast/releases/latest" | jq -r '.tag_name')
-          echo "LATEST_CHROMECASTGOVERSION=$LATEST_VERSION" >> $GITHUB_ENV
-
-      - name: Check if version is newer and update Dockerfile
-        id: check-version-and-update-dockerfile
-        run: |
-          if [[ "${{ env.CURRENT_CHROMECASTGOVERSION }}" == "${{ env.LATEST_CHROMECASTGOVERSION }}" ]]; then
-            echo "No new version available. Skipping Dockerfile update."
-            echo "VERSION_CHANGED=false" >> $GITHUB_ENV
-          else
-            echo "New version available. Updating Dockerfile."
-            echo "VERSION_CHANGED=true" >> $GITHUB_ENV
-            sed -i "s/ENV CHROMECASTGOVERSION=.*/ENV CHROMECASTGOVERSION=${{ env.LATEST_CHROMECASTGOVERSION }}/" ./Dockerfile
-          fi
-      
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2.1.0
-        if: ${{ env.VERSION_CHANGED == 'true' }}
-        
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.5.0
         with:
           install: true
-        if: ${{ env.VERSION_CHANGED == 'true' }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2.1.0
@@ -55,15 +27,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ env.VERSION_CHANGED == 'true' }}
 
       - name: Build and push
         uses: docker/build-push-action@v4.0.0
         with:
-          push: true 
-          context: .
+          push: true
           tags: ghcr.io/${{ github.repository }}:latest
           platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6
-          file: ./Dockerfile
-        if: ${{ env.VERSION_CHANGED == 'true' }}
-

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -32,10 +32,10 @@ jobs:
         run: |
           if [[ "${{ env.CURRENT_CHROMECASTGOVERSION }}" == "${{ env.LATEST_CHROMECASTGOVERSION }}" ]]; then
             echo "No new version available. Skipping Dockerfile update."
-            echo "version_changed=false" >> $GITHUB_ENV
+            echo "VERSION_CHANGED=false" >> $GITHUB_ENV
           else
             echo "New version available. Updating Dockerfile."
-            echo "version_changed=true" >> $GITHUB_ENV
+            echo "VERSION_CHANGED=true" >> $GITHUB_ENV
             sed -i "s/ENV CHROMECASTGOVERSION=.*/ENV CHROMECASTGOVERSION=${{ env.LATEST_CHROMECASTGOVERSION }}/" Dockerfile
           fi
           echo "PREVIOUS_CHROMECASTGOVERSION=${{ env.CURRENT_CHROMECASTGOVERSION }}" >> $GITHUB_ENV

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -42,13 +42,13 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
-        if: steps.check-version-and-update-dockerfile.outputs.version_changed == 'true'
-
+        if: ${{ steps.check-version-and-update-dockerfile.outputs.version_changed == 'true' }}
+        
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
           install: true
-        if: steps.check-version-and-update-dockerfile.outputs.version_changed == 'true'
+        if: ${{ steps.check-version-and-update-dockerfile.outputs.version_changed == 'true' }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1 
@@ -56,7 +56,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        if: steps.check-version-and-update-dockerfile.outputs.version_changed == 'true'
+        if: ${{ steps.check-version-and-update-dockerfile.outputs.version_changed == 'true' }}
 
       - name: Build and push
         uses: docker/build-push-action@v2
@@ -64,4 +64,4 @@ jobs:
           push: true 
           tags: ghcr.io/${{ github.repository }}:latest
           platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6
-        if: steps.check-version-and-update-dockerfile.outputs.version_changed == 'true'
+        if: ${{ steps.check-version-and-update-dockerfile.outputs.version_changed == 'true' }}

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -7,57 +7,49 @@ on:
     branches:
       - main
 
-env:
-  CURRENT_RELEASE_FILE: release.txt
-
 jobs:
   build-multi-arch-image:
     name: Build multi-arch Docker image
     runs-on: ubuntu-latest
     steps:
-      - name: Check for new release
-        id: check_release
-        run: |
-          LATEST_RELEASE=$(curl -sL https://api.github.com/repos/vishen/go-chromecast/releases/latest | jq -r '.tag_name')
-          echo "LATEST_RELEASE=$LATEST_RELEASE" >> $GITHUB_ENV
-          touch release.txt
-          CURRENT_RELEASE=$(cat $CURRENT_RELEASE_FILE)
-          echo "CURRENT_RELEASE=$CURRENT_RELEASE"
-  
-          if [[ "$LATEST_RELEASE" != "$CURRENT_RELEASE" ]]; then
-            echo "$LATEST_RELEASE" > $CURRENT_RELEASE_FILE
-            echo "Updated CURRENT_RELEASE to $LATEST_RELEASE"
-          else
-            echo "No new release found. CURRENT_RELEASE=$CURRENT_RELEASE"
-          fi
-      
       - name: Checkout
-        if: env.LATEST_RELEASE != env.CURRENT_RELEASE
         uses: actions/checkout@v2
 
       - name: Set up QEMU
-        if: env.LATEST_RELEASE != env.CURRENT_RELEASE
         uses: docker/setup-qemu-action@v1
-        
+
       - name: Set up Docker Buildx
-        if: env.LATEST_RELEASE != env.CURRENT_RELEASE
         uses: docker/setup-buildx-action@v1
         with:
           install: true
 
       - name: Login to GitHub Container Registry
-        if: env.LATEST_RELEASE != env.CURRENT_RELEASE
         uses: docker/login-action@v1 
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get current go-chromecast version
+        id: get-chromecast-version
+        run: |
+          CHROMECASTGOVERSION=$(wget -qO- https://api.github.com/repos/vishen/go-chromecast/releases/latest | jq -r '.tag_name')
+          echo "CHROMECASTGOVERSION=$CHROMECASTGOVERSION" >> $GITHUB_ENV
+
+      - name: Check if version is newer
+        id: check-version
+        run: |
+          if [[ "${{ env.CHROMECASTGOVERSION }}" == "${{ secrets.CURRENT_CHROMECASTGOVERSION }}" ]]; then
+            echo "::set-output name=build_required::false"
+          else
+            echo "::set-output name=build_required::true"
+          fi
+
       - name: Build and push
-        if: env.LATEST_RELEASE != env.CURRENT_RELEASE
         uses: docker/build-push-action@v2
         with:
-          push: true 
+          push: ${{ steps.check-version.outputs.build_required }}
           tags: ghcr.io/${{ github.repository }}:latest
           platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6
-
+        env:
+          CHROMECASTGOVERSION: ${{ env.CHROMECASTGOVERSION }}

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -21,6 +21,10 @@ jobs:
           LATEST_RELEASE=$(curl -sL https://api.github.com/repos/vishen/go-chromecast/releases/latest | jq -r '.tag_name')
           echo "::set-output name=release::$LATEST_RELEASE"
 
+      - name: Update CURRENT_RELEASE
+        if: steps.check_release.outputs.release != env.CURRENT_RELEASE
+        run: echo "CURRENT_RELEASE=${{ steps.check_release.outputs.release }}" >> $GITHUB_ENV
+
       - name: Checkout
         if: steps.check_release.outputs.release != env.CURRENT_RELEASE
         uses: actions/checkout@v2

--- a/.github/workflows/check_for_new_go_chromecast.yml
+++ b/.github/workflows/check_for_new_go_chromecast.yml
@@ -1,0 +1,65 @@
+name: build-and-push-image
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Schedule to run once every day
+
+jobs:
+  build-multi-arch-image:
+    name: Build multi-arch Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Get current go-chromecast version from Dockerfile
+        id: get-current-version
+        run: |
+          CURRENT_CHROMECASTGOVERSION=$(grep -oP '(?<=CHROMECASTGOVERSION=).*' ./Dockerfile)
+          echo "CURRENT_CHROMECASTGOVERSION=$CURRENT_CHROMECASTGOVERSION" >> $GITHUB_ENV
+
+      - name: Get latest go-chromecast version
+        id: get-latest-version
+        run: |
+          LATEST_VERSION=$(curl -s "https://api.github.com/repos/vishen/go-chromecast/releases/latest" | jq -r '.tag_name')
+          echo "LATEST_CHROMECASTGOVERSION=$LATEST_VERSION" >> $GITHUB_ENV
+
+      - name: Check if version is newer and update Dockerfile
+        id: check-version-and-update-dockerfile
+        run: |
+          if [[ "${{ env.CURRENT_CHROMECASTGOVERSION }}" == "${{ env.LATEST_CHROMECASTGOVERSION }}" ]]; then
+            echo "No new version available. Skipping Dockerfile update."
+            echo "VERSION_CHANGED=false" >> $GITHUB_ENV
+          else
+            echo "New version available. Updating Dockerfile."
+            echo "VERSION_CHANGED=true" >> $GITHUB_ENV
+            sed -i "s/ENV CHROMECASTGOVERSION=.*/ENV CHROMECASTGOVERSION=${{ env.LATEST_CHROMECASTGOVERSION }}/" ./Dockerfile
+          fi
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+        if: ${{ env.VERSION_CHANGED == 'true' }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.5.0
+        with:
+          install: true
+        if: ${{ env.VERSION_CHANGED == 'true' }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ env.VERSION_CHANGED == 'true' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4.0.0
+        with:
+          push: true
+          context: .
+          tags: ghcr.io/${{ github.repository }}:latest
+          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6
+          file: ./Dockerfile
+        if: ${{ env.VERSION_CHANGED == 'true' }}

--- a/.github/workflows/check_for_new_go_chromecast.yml
+++ b/.github/workflows/check_for_new_go_chromecast.yml
@@ -1,4 +1,4 @@
-name: build-and-push-image
+name: Check for new Go Chromecast version
 
 on:
   schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ARG TARGETARCH
 ARG TARGETVARIANT
 ENV CHROMECASTGOVERSION=v0.2.12
 
-RUN apk --no-cache add jq bc grep curl
-RUN GC_URL=`wget https://api.github.com/repos/vishen/go-chromecast/releases/tags/${CHROMECASTGOVERSION} -O - | jq -r '.assets[].browser_download_url' | grep ${TARGETOS}_${TARGETARCH}${TARGETVARIANT}` \
+RUN apk --no-cache add jq bc grep curl \
+    && GC_URL=`wget https://api.github.com/repos/vishen/go-chromecast/releases/tags/${CHROMECASTGOVERSION} -O - | jq -r '.assets[].browser_download_url' | grep ${TARGETOS}_${TARGETARCH}${TARGETVARIANT}` \
     && wget $GC_URL -O /root/go-chromecast.tgz \
     && tar xzf /root/go-chromecast.tgz -C /usr/bin \
     && rm -rf /root/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ FROM alpine:latest
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT
-ENV CHROMECASTGOVERSION=v0.2.1
+ENV CHROMECASTGOVERSION=v0.2.12
 
-RUN apk --no-cache add jq bc grep curl \
-    && GC_URL=`wget https://api.github.com/repos/vishen/go-chromecast/releases/tags/${CHROMECASTGOVERSION} -O - | jq -r '.assets[].browser_download_url' | grep ${TARGETOS}_${TARGETARCH}${TARGETVARIANT}` \
+RUN apk --no-cache add jq bc grep curl
+RUN GC_URL=`wget https://api.github.com/repos/vishen/go-chromecast/releases/tags/${CHROMECASTGOVERSION} -O - | jq -r '.assets[].browser_download_url' | grep ${TARGETOS}_${TARGETARCH}${TARGETVARIANT}` \
     && wget $GC_URL -O /root/go-chromecast.tgz \
     && tar xzf /root/go-chromecast.tgz -C /usr/bin \
     && rm -rf /root/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:latest
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT
-ENV CHROMECASTGOVERSION=v0.2.12
+ENV CHROMECASTGOVERSION=v0.3.1
 
 RUN apk --no-cache add jq bc grep curl \
     && GC_URL=`wget https://api.github.com/repos/vishen/go-chromecast/releases/tags/${CHROMECASTGOVERSION} -O - | jq -r '.assets[].browser_download_url' | grep ${TARGETOS}_${TARGETARCH}${TARGETVARIANT}` \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,3 +22,4 @@ LABEL Description="Container to run go-chromecast with some preset ENVs, run as 
 ADD sponsorblockcast.sh /usr/bin/sponsorblockcast
 
 CMD /usr/bin/sponsorblockcast
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:latest
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT
-ARG CHROMECASTGOVERSION
+ENV CHROMECASTGOVERSION=v0.2.1
 
 RUN apk --no-cache add jq bc grep curl \
     && GC_URL=`wget https://api.github.com/repos/vishen/go-chromecast/releases/tags/${CHROMECASTGOVERSION} -O - | jq -r '.assets[].browser_download_url' | grep ${TARGETOS}_${TARGETARCH}${TARGETVARIANT}` \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,11 @@ ARG TARGETARCH
 ARG TARGETVARIANT
 
 RUN apk --no-cache add jq bc grep curl \
-  && GC_URL=`wget https://api.github.com/repos/vishen/go-chromecast/releases/latest -O - | jq -r '.assets[].browser_download_url' | grep ${TARGETOS}_${TARGETARCH}${TARGETVARIANT}` \
-  && wget $GC_URL -O /root/go-chromecast.tgz \
-  && tar xzf /root/go-chromecast.tgz -C /usr/bin \
-  && rm -rf /root/* \
-  && chmod +x /usr/bin/go-chromecast
+    && GC_URL=`wget https://api.github.com/repos/vishen/go-chromecast/releases/tags/${CHROMECASTGOVERSION} -O - | jq -r '.assets[].browser_download_url' | grep ${TARGETOS}_${TARGETARCH}${TARGETVARIANT}` \
+    && wget $GC_URL -O /root/go-chromecast.tgz \
+    && tar xzf /root/go-chromecast.tgz -C /usr/bin \
+    && rm -rf /root/* \
+    && chmod +x /usr/bin/go-chromecast
 
 ENV SBCPOLLINTERVAL 1
 ENV SBCSCANINTERVAL 300

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM alpine:latest
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT
+ARG CHROMECASTGOVERSION
 
 RUN apk --no-cache add jq bc grep curl \
     && GC_URL=`wget https://api.github.com/repos/vishen/go-chromecast/releases/tags/${CHROMECASTGOVERSION} -O - | jq -r '.assets[].browser_download_url' | grep ${TARGETOS}_${TARGETARCH}${TARGETVARIANT}` \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   sponsorblockcast:
-    image: ghcr.io/bruvv/sponsorblockcast:latest
+    image: ghcr.io/nichobi/sponsorblockcast:latest
     network_mode: host
     environment:
       SBCPOLLINTERVAL: 1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   sponsorblockcast:
-    image: ghcr.io/nichobi/sponsorblockcast:latest
+    image: ghcr.io/bruvv/sponsorblockcast:latest
     network_mode: host
     environment:
       SBCPOLLINTERVAL: 1
@@ -11,3 +11,8 @@ services:
     cap_add: 
       - NET_ADMIN
     restart: always
+    healthcheck:
+      test: ["CMD", "go-chromecast", "ls"]
+      interval: 60s
+      timeout: 10s
+      retries: 3


### PR DESCRIPTION
Made an extra build that runs every night, gets the current `ENV CHROMECASTGOVERSION=v0.3.1` from the dockfile and compares it with the remote version using the github api. If there is a new version, it will make a new dockerfile, adjust it with sed and push a new image.

Do note: It will NOT update the Dockerfile in the repo (for ophious reasons).

Also added a healtcheck from this "issue": https://github.com/nichobi/sponsorblockcast/issues/29