### PR TITLE
encode params to avoid non rfc3986 compliant uri

### DIFF
--- a/sponsorblockcast.sh
+++ b/sponsorblockcast.sh
@@ -36,7 +36,8 @@ get_segments () {
   if [ -n "$id" ] && [ ! -f "$id".json ]
   then
     curl -fs --get "https://sponsor.ajay.app/api/skipSegments" \
-      --data "videoID=$id" --data "categories=$categories" > "$id".json
+      --data-urlencode "videoID=$id" \
+      --data-urlencode "categories=$categories" > "$id".json
     [ -s "$id".json ] \
       && echo "$(jq '.[].segment[1]' "$id".json | wc -l) skippable segments found for video $id" \
       || echo "No skippable segments found for video $id"


### PR DESCRIPTION
$categories contains square brackets, which must be encoded when used in a URI. Aside from this, the cloudflare load balancer in front of [sponsor.ajay.app](https://sponsor.ajay.app/api/) has inconsistent behavior when handling URIs with unencoded square brackets, resulting in unhandled 400 errors.